### PR TITLE
Add basic multi-map exploration

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -313,3 +313,26 @@ Date: March 27, 2024
 ### Next Steps:
 
 *   Proceed to Step 7: Design a Small Explorable Map, focusing on expanding the game world.
+
+## Step 7: Design a Small Explorable Map (Completed)
+
+Date: June 7, 2025
+
+### Tasks Accomplished:
+
+1. Created two distinct map areas using the grid utilities:
+   * **Slums** – a 20x20 zone with building obstacles and a door on the east side.
+   * **Downtown** – another 20x20 zone with its own arrangement of walls and a door on the west side.
+2. Implemented a simple world map module (`worldMap.ts`) that stores these areas and defines connections between them.
+3. Extended `worldSlice` to keep a dictionary of map areas and set the initial map to the Slums.
+4. Updated `GameController` to detect door tiles. Moving onto a door now triggers a map change and positions the player at the appropriate entry point in the destination area.
+5. Modified `MainScene` so it redraws the map and enemies whenever the current map area changes, enabling seamless transitions.
+
+### Notes:
+
+* Walking through a door moves the player between Slums and Downtown without restarting the scene.
+* Walls inside each area prevent movement through buildings as intended.
+
+### Next Steps:
+
+* Continue with Step 8: Add a Day-Night Cycle to affect visibility in the world.

--- a/the-getaway/src/__tests__/grid.test.ts
+++ b/the-getaway/src/__tests__/grid.test.ts
@@ -150,22 +150,23 @@ describe('Grid System', () => {
     // Should have at least some adjacent walkable positions
     expect(adjacentPositions.length).toBeGreaterThan(0);
     
-    // All returned positions should be walkable
-    adjacentPositions.forEach(pos => {
-      expect(isPositionWalkable(pos, testMap, dummyPlayer, dummyEnemies)).toBe(
-        true
-      );
-    
-    // Should not include the original position
-    expect(adjacentPositions.some(pos => pos.x === position.x && pos.y === position.y)).toBe(false);
-    
-    // Should only include positions that are one step away
-    adjacentPositions.forEach(pos => {
-      const dx = Math.abs(pos.x - position.x);
-      const dy = Math.abs(pos.y - position.y);
-      
-      // Should be either horizontal or vertical neighbor (not diagonal)
-      expect((dx === 1 && dy === 0) || (dx === 0 && dy === 1)).toBe(true);
-    });
+  // All returned positions should be walkable
+  adjacentPositions.forEach(pos => {
+    expect(isPositionWalkable(pos, testMap, dummyPlayer, dummyEnemies)).toBe(
+      true
+    );
   });
-}); 
+
+  // Should not include the original position
+  expect(adjacentPositions.some(pos => pos.x === position.x && pos.y === position.y)).toBe(false);
+
+  // Should only include positions that are one step away
+  adjacentPositions.forEach(pos => {
+    const dx = Math.abs(pos.x - position.x);
+    const dy = Math.abs(pos.y - position.y);
+
+    // Should be either horizontal or vertical neighbor (not diagonal)
+    expect((dx === 1 && dy === 0) || (dx === 0 && dy === 1)).toBe(true);
+  });
+});
+});

--- a/the-getaway/src/components/GameController.tsx
+++ b/the-getaway/src/components/GameController.tsx
@@ -15,8 +15,10 @@ import {
   isInAttackRange,
   DEFAULT_ATTACK_COST,
 } from "../game/combat/combatSystem";
-import { Enemy, Position, MapArea } from "../game/interfaces/types";
+import { Enemy, Position, MapArea, TileType } from "../game/interfaces/types";
 import { determineEnemyMove } from "../game/combat/enemyAI";
+import { mapAreas, getConnectionForPosition } from "../game/world/worldMap";
+import { setMapArea } from "../store/worldSlice";
 
 const GameController: React.FC = () => {
   const dispatch = useDispatch();
@@ -428,7 +430,19 @@ const GameController: React.FC = () => {
 
       // Check if the new position is walkable
       if (isPositionWalkable(newPosition, currentMapArea, player, enemies)) {
-        dispatch(movePlayer(newPosition));
+        const tile = currentMapArea.tiles[newPosition.y][newPosition.x];
+        const connection = getConnectionForPosition(
+          currentMapArea.id,
+          newPosition
+        );
+
+        if (tile.type === TileType.DOOR && connection) {
+          const targetArea = mapAreas[connection.toAreaId];
+          dispatch(setMapArea(targetArea));
+          dispatch(movePlayer(connection.toPosition));
+        } else {
+          dispatch(movePlayer(newPosition));
+        }
         // dispatch(addLogMessage({ type: "info", message: `Moved to (${newPosition.x}, ${newPosition.y})` })); // COMMENTED OUT
         if (inCombat) {
           console.log("[GameController] handleKeyDown: PRE-MOVE AP DEDUCTION", {

--- a/the-getaway/src/game/scenes/MainScene.ts
+++ b/the-getaway/src/game/scenes/MainScene.ts
@@ -88,9 +88,16 @@ export class MainScene extends Phaser.Scene {
     const worldState = newState.world;
     const currentEnemies = worldState.currentMapArea.entities.enemies;
 
-    if(this.currentMapArea.id !== worldState.currentMapArea.id) {
-        console.warn("[MainScene handleStateChange] Map area mismatch, scene might need restarting.");
-        return;
+    if (this.currentMapArea.id !== worldState.currentMapArea.id) {
+      console.log('[MainScene] Map area changed, updating scene');
+      this.currentMapArea = worldState.currentMapArea;
+      // clear existing enemy sprites
+      this.enemySprites.forEach((data) => {
+        data.sprite.destroy();
+        data.healthText.destroy();
+      });
+      this.enemySprites.clear();
+      this.setupCameraAndMap();
     }
 
     this.updatePlayerPosition(playerState.position);

--- a/the-getaway/src/game/world/worldMap.ts
+++ b/the-getaway/src/game/world/worldMap.ts
@@ -1,0 +1,92 @@
+import { MapArea, Position, TileType } from '../interfaces/types';
+import { createBasicMapArea, addWalls } from './grid';
+
+export interface MapConnection {
+  fromAreaId: string;
+  fromPosition: Position;
+  toAreaId: string;
+  toPosition: Position;
+}
+
+const createSlumsArea = (): MapArea => {
+  const area = createBasicMapArea('Slums', 20, 20);
+  const walls: Position[] = [];
+
+  for (let x = 4; x <= 6; x++) {
+    for (let y = 4; y <= 8; y++) {
+      walls.push({ x, y });
+    }
+  }
+
+  for (let x = 12; x <= 15; x++) {
+    for (let y = 10; y <= 13; y++) {
+      walls.push({ x, y });
+    }
+  }
+
+  const withWalls = addWalls(area, walls);
+  // Door to Downtown on the east edge
+  const door = withWalls.tiles[10][19];
+  door.type = TileType.DOOR;
+  door.isWalkable = true;
+  return withWalls;
+};
+
+const createDowntownArea = (): MapArea => {
+  const area = createBasicMapArea('Downtown', 20, 20);
+  const walls: Position[] = [];
+
+  for (let x = 5; x <= 8; x++) {
+    for (let y = 5; y <= 7; y++) {
+      walls.push({ x, y });
+    }
+  }
+
+  for (let x = 14; x <= 17; x++) {
+    for (let y = 2; y <= 5; y++) {
+      walls.push({ x, y });
+    }
+  }
+
+  const withWalls = addWalls(area, walls);
+  // Door to Slums on the west edge
+  const door = withWalls.tiles[10][0];
+  door.type = TileType.DOOR;
+  door.isWalkable = true;
+  return withWalls;
+};
+
+export const slumsArea = createSlumsArea();
+export const downtownArea = createDowntownArea();
+
+export const mapAreas: Record<string, MapArea> = {
+  [slumsArea.id]: slumsArea,
+  [downtownArea.id]: downtownArea,
+};
+
+export const mapConnections: MapConnection[] = [
+  {
+    fromAreaId: slumsArea.id,
+    fromPosition: { x: 19, y: 10 },
+    toAreaId: downtownArea.id,
+    toPosition: { x: 1, y: 10 },
+  },
+  {
+    fromAreaId: downtownArea.id,
+    fromPosition: { x: 0, y: 10 },
+    toAreaId: slumsArea.id,
+    toPosition: { x: 18, y: 10 },
+  },
+];
+
+export const getConnectionForPosition = (
+  areaId: string,
+  position: Position
+): MapConnection | undefined => {
+  return mapConnections.find(
+    (c) =>
+      c.fromAreaId === areaId &&
+      c.fromPosition.x === position.x &&
+      c.fromPosition.y === position.y
+  );
+};

--- a/the-getaway/src/store/worldSlice.ts
+++ b/the-getaway/src/store/worldSlice.ts
@@ -1,18 +1,19 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { randomUUID } from 'crypto';
 import { MapArea, Enemy, NPC, Position, Item } from '../game/interfaces/types';
-import { createOpenMapArea } from '../game/world/grid';
+import { mapAreas, slumsArea } from '../game/world/worldMap';
 
 export interface WorldState {
   currentMapArea: MapArea;
+  mapAreas: Record<string, MapArea>;
   currentTime: number;
   inCombat: boolean;
   isPlayerTurn: boolean;
   turnCount: number;
 }
 
-// Use the new function to create the initial map (20x20)
-const initialMap = createOpenMapArea('Open Area', 20, 20);
+// Initial map areas are created in worldMap.ts
+const initialMap = slumsArea;
 const initialEnemy: Enemy = {
   id: randomUUID(),
   name: "Guard",
@@ -27,10 +28,11 @@ const initialEnemy: Enemy = {
   isHostile: true,
 };
 initialMap.entities.enemies.push(initialEnemy);
-console.log("[worldSlice] Initial open map generated with enemy:", initialEnemy);
+console.log("[worldSlice] Initial map generated with enemy:", initialEnemy);
 
 const initialState: WorldState = {
   currentMapArea: initialMap,
+  mapAreas,
   currentTime: 0,
   inCombat: false,
   isPlayerTurn: true,


### PR DESCRIPTION
## Summary
- create `worldMap` module with Slums and Downtown areas
- store map collection in `worldSlice` and start player in Slums
- support door-based map transitions in `GameController`
- refresh `MainScene` when the map changes
- fix grid tests and update progress documentation

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6843f8fd5f08832fa2b399e2fdb41cae