### PR TITLE
Set up GitHub Pages deployment pipeline

### DIFF
--- a/the-getaway/.github/workflows/ci-pages.yml
+++ b/the-getaway/.github/workflows/ci-pages.yml
@@ -1,0 +1,69 @@
+name: CI and GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: the-getaway/the-getaway
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: the-getaway/the-getaway/yarn.lock
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Run tests
+        run: yarn test --runInBand
+
+      - name: Build
+        run: yarn build
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: the-getaway/the-getaway/dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/the-getaway/README.md
+++ b/the-getaway/README.md
@@ -1,54 +1,35 @@
-# React + TypeScript + Vite
+# The Getaway
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A Phaser-powered tactics prototype built with React, Redux Toolkit, and Vite. The project now includes a fully automated CI/CD pipeline that tests, builds, and deploys the site to GitHub Pages for release snapshots.
 
-Currently, two official plugins are available:
+## Local development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```bash
+yarn dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Runs the development server with hot module replacement. Additional helpful commands:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+- `yarn lint` – ESLint validation.
+- `yarn test` – Jest unit tests (jsdom environment).
+- `yarn build` – Type-checks and generates a production bundle in `dist/`.
+- `yarn preview` – Serves the built bundle locally.
 
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
-```
+## Continuous integration & deployment
+
+The workflow in [`.github/workflows/ci-pages.yml`](.github/workflows/ci-pages.yml) performs the following on every push and pull request targeting `main`:
+
+1. Installs dependencies with Yarn using Node.js 20.
+2. Runs linting and unit tests to guard code quality.
+3. Builds the production bundle.
+4. When running on `main`, uploads the bundle as a Pages artifact and deploys it to the `github-pages` environment.
+
+You can also trigger the workflow manually from the **Actions** tab via the "Run workflow" button (workflow dispatch).
+
+## GitHub Pages
+
+The Vite configuration automatically detects the repository name when running in GitHub Actions and sets the correct `base` path so assets resolve under `https://<your-username>.github.io/<repository>/`.
+
+Once the workflow finishes successfully on `main`, GitHub Pages publishes the latest build at the URL reported in the workflow summary. This first deployment acts as the initial public release of the project.
+
+If you fork the repository under a different name, the base path will update automatically without further changes.

--- a/the-getaway/package.json
+++ b/the-getaway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-getaway",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-getaway/vite.config.ts
+++ b/the-getaway/vite.config.ts
@@ -1,8 +1,14 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+const repository = process.env.GITHUB_REPOSITORY;
+const isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
+const repoName = repository?.split('/')[1];
+const base = isGitHubActions && repoName ? `/${repoName}/` : '/';
 
 // https://vite.dev/config/
 export default defineConfig({
+  base,
   plugins: [react()],
   build: {
     rollupOptions: {
@@ -39,4 +45,4 @@ export default defineConfig({
     },
     chunkSizeWarningLimit: 1500, // Phaser alone is ~1.4MB, which is expected
   },
-})
+});


### PR DESCRIPTION
## Summary
- configure the Vite base path so builds work when hosted on GitHub Pages
- add a CI workflow that lints, tests, builds, and deploys the site to the GitHub Pages environment
- refresh the README with CI/CD guidance and mark the package as version 1.0.0 for the initial release

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e6e8f4e4f0832f83e12cd82eb66e48