### PR TITLE
Fix minimap canvas context access in tests

### DIFF
--- a/the-getaway/src/components/ui/MiniMap.tsx
+++ b/the-getaway/src/components/ui/MiniMap.tsx
@@ -71,8 +71,16 @@ const toRadians = (degrees: number): number => (degrees * Math.PI) / 180;
 
 const distanceBetween = (a: Position, b: Position): number => Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
 
+const isJsdomEnvironment = (): boolean => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  return /jsdom/i.test(navigator.userAgent ?? '');
+};
+
 const get2dContext = (canvas: HTMLCanvasElement | null): CanvasRenderingContext2D | null => {
-  if (!canvas || typeof canvas.getContext !== 'function') {
+  if (!canvas || typeof canvas.getContext !== 'function' || isJsdomEnvironment()) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- add an environment helper to detect jsdom
- skip MiniMap canvas context access when running under jsdom to avoid noisy errors during tests

## Testing
- yarn test --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e81b8108e4832f8b75476cf701d02c