### PR TITLE
chore: add scoped logger for debug output

### DIFF
--- a/the-getaway/src/App.tsx
+++ b/the-getaway/src/App.tsx
@@ -30,6 +30,7 @@ import { DEFAULT_SKILLS } from "./game/interfaces/player";
 import { getUIStrings } from "./content/ui";
 import { getSystemStrings } from "./content/system";
 import { listPerks, evaluatePerkAvailability } from "./content/perks";
+import { createScopedLogger } from "./utils/logger";
 import MissionCompletionOverlay from "./components/ui/MissionCompletionOverlay";
 import "./App.css";
 
@@ -43,6 +44,8 @@ const LevelUpPointAllocationPanel = lazy(() => import("./components/ui/LevelUpPo
 
 // Type import for CharacterCreationData
 import type { CharacterCreationData } from "./components/ui/CharacterCreationScreen";
+
+const log = createScopedLogger('App');
 
 const layoutShellStyle: CSSProperties = {
   margin: 0,
@@ -568,8 +571,8 @@ function App() {
   const [levelPanelCollapsed, setLevelPanelCollapsed] = useState(false);
 
   useEffect(() => {
-    console.log("[App] Component mounted");
-    console.log("[App] Store state:", store.getState());
+    log.debug('Component mounted');
+    log.debug('Store state:', store.getState());
   }, []);
 
   useEffect(() => {

--- a/the-getaway/src/components/ui/SkillTreePanel.tsx
+++ b/the-getaway/src/components/ui/SkillTreePanel.tsx
@@ -7,6 +7,9 @@ import { describeSkillEffect, getPlayerSkillValue, getSkillPointIncrement, isSki
 import NotificationBadge from './NotificationBadge';
 import { gradientTextStyle } from './theme';
 import { allocateSkillPointToSkill, refundSkillPointFromSkill } from '../../store/playerSlice';
+import { createScopedLogger } from '../../utils/logger';
+
+const log = createScopedLogger('SkillTreePanel');
 
 const panelStyle: React.CSSProperties = {
   background: 'transparent',
@@ -234,7 +237,7 @@ const SkillTreePanel: React.FC = () => {
   }, [player.skillTraining]);
 
   const switchBranch = useCallback((branchId: SkillBranchId) => {
-    console.log('[SkillTreePanel] Switching to branch:', branchId);
+    log.debug('Switching to branch:', branchId);
     setActiveBranch(branchId);
     const target = tabRefs.current[branchId];
     if (target) {
@@ -314,7 +317,7 @@ const SkillTreePanel: React.FC = () => {
 
   const activeBranchDefinition = getBranchById(activeBranch);
 
-  console.log('[SkillTreePanel] Render - Active branch:', activeBranch, 'Branch:', activeBranchDefinition.label);
+  log.debug('Render - Active branch:', activeBranch, 'Branch:', activeBranchDefinition.label);
 
   return (
     <section style={panelStyle} aria-labelledby="skill-tree-title">
@@ -350,7 +353,7 @@ const SkillTreePanel: React.FC = () => {
               tabIndex={0}
               onKeyDown={(event) => handleTabKeyDown(event, branch.id)}
               onClick={() => {
-                console.log('[SkillTreePanel] Tab clicked:', branch.id, branch.label);
+                log.debug('Tab clicked:', branch.id, branch.label);
                 switchBranch(branch.id);
               }}
               style={tabStyle(selected)}

--- a/the-getaway/src/utils/logger.ts
+++ b/the-getaway/src/utils/logger.ts
@@ -1,0 +1,62 @@
+const noop = () => undefined;
+
+type LogMethod = (...args: unknown[]) => void;
+
+type ConsoleMethod = 'debug' | 'info' | 'warn' | 'error';
+
+const resolveEnvironment = (): string => {
+  if (typeof process !== 'undefined' && process.env?.NODE_ENV) {
+    return process.env.NODE_ENV;
+  }
+
+  return 'development';
+};
+
+const hasVerboseOverride = (): boolean => {
+  const overrideFlags = [
+    typeof process !== 'undefined' ? process.env?.ENABLE_VERBOSE_LOGS : undefined,
+    typeof globalThis !== 'undefined'
+      ? (globalThis as { __ENABLE_VERBOSE_LOGS?: unknown }).__ENABLE_VERBOSE_LOGS
+      : undefined,
+  ];
+
+  return overrideFlags.some((flag) => {
+    if (typeof flag === 'string') {
+      return flag.toLowerCase() === 'true';
+    }
+    return flag === true;
+  });
+};
+
+const shouldSuppressLogs = !hasVerboseOverride() && resolveEnvironment() === 'test';
+
+const getConsoleMethod = (method: ConsoleMethod): LogMethod => {
+  const candidate = console[method] ?? console.log;
+  if (typeof candidate === 'function') {
+    return candidate.bind(console);
+  }
+  return console.log.bind(console);
+};
+
+const bindConsoleMethod = (method: ConsoleMethod, scope: string): LogMethod => {
+  const consoleMethod = getConsoleMethod(method);
+
+  if (shouldSuppressLogs && (method === 'debug' || method === 'info')) {
+    return noop;
+  }
+
+  return (...args: unknown[]) => {
+    consoleMethod(`[${scope}]`, ...args);
+  };
+};
+
+export type ScopedLogger = Record<ConsoleMethod, LogMethod>;
+
+export const createScopedLogger = (scope: string): ScopedLogger => ({
+  debug: bindConsoleMethod('debug', scope),
+  info: bindConsoleMethod('info', scope),
+  warn: bindConsoleMethod('warn', scope),
+  error: bindConsoleMethod('error', scope),
+});
+
+export const logger = createScopedLogger('app');


### PR DESCRIPTION
## Summary
- add a scoped logging utility that suppresses debug/info chatter during tests while allowing opt-in overrides
- replace direct console usage in world, app, game controller, and skill tree components with the new scoped logger

## Testing
- npx jest --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e8bb504e60832fafbee5e4e1fb7df0