### PR TITLE
Add localized witness reputation system to design docs

### DIFF
--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -200,6 +200,35 @@ Dedicated folder for reusable React UI components, separate from core game logic
 <code_location>the-getaway/src/components/ui/MiniMap.tsx</code_location>
 </architecture_section>
 
+<architecture_section id="localized_reputation_network" category="gameplay_systems">
+<design_principles>
+- Scope notoriety updates to the smallest meaningful audience first (witness → faction → neighborhood) so systemic reactions stay believable and performant.
+- Keep event sensing, witness evaluation, interpretation, propagation, and reaction decoupled through message contracts to minimize feedback loops between UI, AI, and data layers.
+- Budget rumor spread and decay inside the system itself so designers tweak pacing without touching consuming systems.
+</design_principles>
+
+<technical_flow>
+1. <code_location>the-getaway/src/game/systems/reputation/events.ts</code_location> exposes `emitReputationEvent` which game actions call with trait tags, intensity, and location metadata. Events fan out through an in-memory queue managed by `reputationSystem`.
+2. <code_location>the-getaway/src/game/systems/reputation/witnessService.ts</code_location> samples NPCs from the active `MapCell`, computes `visibilityScore = los * distanceFalloff * lighting * disguise * noise`, and yields `WitnessCandidate` objects. Candidates below threshold τ are flagged as rumor-only observers.
+3. <code_location>the-getaway/src/game/systems/reputation/interpretation.ts</code_location> merges candidate data with faction value tables and personal bias traits to generate `WitnessRecord` entries containing trait deltas, confidence, and perceived alignment. Records persist to <code_location>the-getaway/src/store/reputationSlice.ts</code_location> for auditing.
+4. <code_location>the-getaway/src/store/reputationSlice.ts</code_location> maintains layered `ReputationProfile` maps keyed by witness ID, faction ID, and `cellId`. Reducers apply weighted deltas, schedule decay ticks, and expose selectors for scoped lookups (e.g., `selectCellReputation(cellId, trait)`).
+5. <code_location>the-getaway/src/game/systems/reputation/propagationService.ts</code_location> advances bounded gossip edges once per heartbeat using NPC social graphs pulled from `npcDirectory`. Each edge stores strength, latency, and remaining gossip energy to cap daily rumor spread.
+6. Consumers pull scoped data through selectors: `DialogueController` adjusts available lines, `PricingService` modifies price multipliers, `GuardAIController` escalates alertness, and `QuestGatingService` unlocks/locks missions based on the relevant audience’s perception.
+7. Developer tooling lives in <code_location>the-getaway/src/debug/reputationInspector.tsx</code_location> and <code_location>the-getaway/src/debug/reputationHeatmapLayer.tsx</code_location>, rendering overlays that visualize trait intensity by cell and witness breakdowns for tuning.
+</technical_flow>
+
+<pattern name="RumorPropagationBudget">
+- Each NPC carries a `gossipEnergy` counter replenished daily; propagation edges consume energy per hop, enforcing slow spread without bespoke timers in consumers.
+- Latency offsets ensure rumors resolve after a delay rather than instantly applying deltas, enabling designers to stage delayed reactions.
+- Intensity gates allow catastrophic events to bypass normal caps by flagging `allowCrossCell` when thresholds exceed configured bounds.
+</pattern>
+
+<pattern name="ScopedReputationLookup">
+- Selector priority order: direct witness override → social graph aggregate → faction aggregate → cell aggregate → fallback to global faction standing (Step 29).
+- Each selector returns both score and confidence so UI and AI can present uncertain reactions (“I heard…” vs “I saw…”).
+- Hooks expose subscription APIs for React HUD (discount banners, dialogue hints) without leaking Redux internals into Phaser systems.
+</pattern>
+</architecture_section>
 ### `/the-getaway/src/content`
 
 Authorial data that defines the playable world, separated from runtime systems so levels can be versioned and reviewed independently.

--- a/memory-bank/game-design.md
+++ b/memory-bank/game-design.md
@@ -52,6 +52,41 @@ The game world is persistent and simulated, meaning changes endure and NPCs beha
 These systems ensure the city feels alive and immersive. The player is one part of a larger ecosystem, and the world can surprise them with new developments during their journey.
 </mechanic>
 
+<mechanic name="localized_reputation_network">
+Localized Reputation & Gossip System
+
+The city remembers what it actually sees. Instead of a single global meter, reputation propagates through witnesses and their social webs so fame and infamy feel rooted in specific places and crews.
+
+**Core Loop**
+        •       **Sense**: Any notable deed (heroic rescue, brutal execution, slick theft, dazzling competence) emits a `ReputationEvent` tagged with traits, intensity, and context (district cell, time of day, factions involved).
+        •       **Perceive**: Potential witnesses are sampled from the active map cell. Each calculates a visibility score factoring line-of-sight, distance, lighting, crowd density, disguise modifiers, and ambient noise. Sub-threshold observers become rumor fodder rather than eyewitnesses.
+        •       **Interpret**: Witnesses filter events through faction values and personal biases to produce trait deltas (heroic, cruel, sneaky, intimidating, competent) with a confidence grade. Saving a raider hostage might read as “honorable” to fellow raiders but “traitorous” to settlers.
+        •       **Write**: Scoped reputation buckets update for the individual witness, their faction, and the local neighborhood cell. High confidence yields stronger adjustments; low confidence generates tentative rumors that affect dialogue tone but not hard gating.
+        •       **Propagate**: Gossip travels across pre-authored social links with latency, falloff, and daily "gossip energy" budgets so stories spread in pockets. Intense, spectacular events can jump cells; mundane actions usually stay local.
+        •       **React**: NPC behaviors (prices, quest offers, guard alertness, bouncer access) read the highest-weighted reputation scope relevant to their relationship. A vendor who watched you defend their stall grants discounts immediately; their cousin down the block hears later.
+        •       **Decay**: Trait scores degrade toward neutral unless refreshed, preventing permanent notoriety from a single incident and encouraging players to cultivate their image intentionally.
+
+**Design Principles**
+        •       **Local First**: Start with per-cell reputation to ensure District A can adore the player while District B shrugs.
+        •       **Subjective Truth**: Factions interpret the same act differently; conflicting rumors can coexist until clarified by direct observation.
+        •       **Uncertainty in Dialogue**: NPCs surface their confidence—"I heard you iced those CorpSec goons" (low confidence) vs. "I saw you drag Mara out of the fire" (high confidence).
+        •       **Budgeted Gossip**: Each NPC has limited rumor tokens per day, preventing instant world coverage and letting designers tune information speed.
+        •       **Heuristic Flavor**: Quick-feel formulas keep events punchy (e.g., Scary = weapon weight × finisher style × bloodiness × crowd density; Helpful = lives saved × aid value × risk × style bonus).
+
+**Gameplay Hooks**
+        •       **Economy**: Shopkeepers who witnessed heroics apply 10–20% discounts; rival witnesses impose surcharges until you repair your image.
+        •       **Access Control**: Bouncers or gate guards rely on their clique’s perception to open back rooms or lock you out. Flashy intimidation builds unlock intimidation-only routes where locals watched you dismantle threats.
+        •       **Law & Security**: Guard responses escalate only in cells where hostility has been observed or gossiped with high confidence; elsewhere they remain neutral.
+        •       **Quest Variants**: Missions reframe based on localized reputation—districts that saw your collateral damage request clean-up gigs, while others pitch you as a covert hero.
+
+**Authoring & Debugging Tools**
+        •       **Heatmap Overlay**: Visualize trait perception per cell to tune propagation falloff.
+        •       **NPC Inspector**: Inspectors list top-three traits, confidence, and rumor sources so writers can adjust dialogue lines.
+        •       **Sandbox Controls**: Designers can scrub decay rates, propagation caps, and thresholds live to feel how fast stories travel.
+
+This system reinforces stealth, intimidation, and altruism builds by rewarding intentional play in front of the right audience while keeping the city’s reaction plausibly fragmented.
+</mechanic>
+
 <mechanic name="ai_assistant">
 AI Assistant & Player Guidance
 


### PR DESCRIPTION
## Summary
- add MVP roadmap step for localized witness-driven reputation propagation
- document gameplay intent for the localized reputation and gossip network in the design file
- capture supporting architectural flows and selectors for the localized reputation system

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e8cd7dbe44832fa872e9ea2a8e6e87