### PR TITLE
Add semantic versioning to menu and CI

### DIFF
--- a/.github/workflows/ci-pages.yml
+++ b/.github/workflows/ci-pages.yml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      app-version: ${{ steps.version_check.outputs.version }}
     defaults:
       run:
         working-directory: the-getaway
@@ -41,6 +43,13 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Verify release version
+        id: version_check
+        run: |
+          VERSION=$(node ./scripts/check-version.mjs)
+          echo "APP_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Lint
         run: yarn lint
 
@@ -60,10 +69,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name != 'pull_request'
+    env:
+      APP_VERSION: ${{ needs.build.outputs.app-version }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Announce release version
+        run: echo "Deploying The Getaway version $APP_VERSION"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/the-getaway/package.json
+++ b/the-getaway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-getaway",
   "private": true,
-  "version": "1.0.0",
+  "version": "2025.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-getaway/scripts/check-version.mjs
+++ b/the-getaway/scripts/check-version.mjs
@@ -1,0 +1,47 @@
+import { readFile } from "node:fs/promises";
+
+const packageJsonUrl = new URL("../package.json", import.meta.url);
+const packageJsonRaw = await readFile(packageJsonUrl, "utf8");
+const packageJson = JSON.parse(packageJsonRaw);
+
+const { version } = packageJson;
+
+if (typeof version !== "string") {
+  console.error("package.json is missing a semantic version string.");
+  process.exit(1);
+}
+
+const semverPattern = /^(\d{4})\.(\d+)\.(\d+)$/;
+const match = version.match(semverPattern);
+
+if (!match) {
+  console.error(
+    `Version \"${version}\" must follow the format <year>.<minor>.<patch> (e.g. 2025.1.0).`,
+  );
+  process.exit(1);
+}
+
+const [, majorYear, minor, patch] = match;
+
+for (const [label, part] of [
+  ["minor", minor],
+  ["patch", patch],
+]) {
+  const numericPart = Number(part);
+
+  if (!Number.isInteger(numericPart) || numericPart < 0) {
+    console.error(`Version ${label} component \"${part}\" must be a non-negative integer.`);
+    process.exit(1);
+  }
+}
+
+const currentYear = new Date().getFullYear();
+
+if (Number(majorYear) !== currentYear) {
+  console.error(
+    `Version year ${majorYear} does not match the current year ${currentYear}.`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(`${version}`);

--- a/the-getaway/src/components/ui/GameMenu.tsx
+++ b/the-getaway/src/components/ui/GameMenu.tsx
@@ -7,6 +7,7 @@ import { applyLocaleToQuests } from "../../store/questsSlice";
 import { applyLocaleToWorld } from "../../store/worldSlice";
 import { applyLocaleToMissions } from "../../store/missionSlice";
 import { RootState, AppDispatch } from "../../store";
+import { GAME_VERSION, GAME_YEAR } from "../../version";
 import EnhancedButton from "./EnhancedButton";
 import { gradientTextStyle } from "./theme";
 
@@ -302,9 +303,18 @@ const GameMenu: React.FC<GameMenuProps> = ({
             textTransform: "uppercase",
             color: "#64748b",
             textAlign: "center",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "0.65rem",
+            flexWrap: "wrap",
           }}
         >
-          {strings.menu.alphaLabel(new Date().getFullYear())}
+          <span>{strings.menu.alphaLabel(GAME_YEAR)}</span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem", color: "#94a3b8" }}>
+            <span aria-hidden="true">•</span>
+            <span>{`v${GAME_VERSION}`}</span>
+          </span>
         </div>
       </div>
     </div>

--- a/the-getaway/src/version.ts
+++ b/the-getaway/src/version.ts
@@ -1,0 +1,12 @@
+import packageJson from "../package.json";
+
+const versionPattern = /^(\d{4})\.(\d+)\.(\d+)$/;
+
+const versionMatch = typeof packageJson.version === "string"
+  ? packageJson.version.match(versionPattern)
+  : null;
+
+const fallbackYear = new Date().getFullYear();
+
+export const GAME_VERSION = packageJson.version ?? "0.0.0";
+export const GAME_YEAR = versionMatch ? Number(versionMatch[1]) : fallbackYear;


### PR DESCRIPTION
## Summary
- set the project version to a year-based semantic tag and expose it for runtime use
- surface the build version beside the alpha label in the main menu
- teach the CI workflow to validate and broadcast the release version before deploys

## Testing
- yarn test --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e8cf973600832f9400b460cbf559b5